### PR TITLE
refactor: split repository methods into add, update, and get

### DIFF
--- a/CandidateManagement.Application/Repositories/ICandidateRepository.cs
+++ b/CandidateManagement.Application/Repositories/ICandidateRepository.cs
@@ -5,5 +5,6 @@ namespace CandidateManagement.Application.Repositories;
 public interface ICandidateRepository
 {
     Task<Candidate?> GetByEmailAsync(string email);
-    Task AddOrUpdateAsync(Candidate candidate);
+    Task AddCandidateAsync(Candidate candidate);
+    Task UpdateCandidateAsync(Candidate candidate);
 }

--- a/CandidateManagement.Infrastructure/Repositories/CandidateRepository.cs
+++ b/CandidateManagement.Infrastructure/Repositories/CandidateRepository.cs
@@ -16,21 +16,19 @@ public class CandidateRepository : ICandidateRepository
 
     public async Task<Candidate?> GetByEmailAsync(string email)
     {
-        return await _context.Candidates.FirstOrDefaultAsync(c => c.Email == email);
+        return await _context.Candidates.AsNoTracking()
+            .FirstOrDefaultAsync(c => c.Email == email);
     }
 
-    public async Task AddOrUpdateAsync(Candidate candidate)
+    public async Task AddCandidateAsync(Candidate candidate)
     {
-        var existingCandidate = await GetByEmailAsync(candidate.Email);
-        if (existingCandidate != null)
-        {
-            _context.Entry(existingCandidate).CurrentValues.SetValues(candidate);
-        }
-        else
-        {
-            await _context.Candidates.AddAsync(candidate);
-        }
+        await _context.Candidates.AddAsync(candidate);
+        await _context.SaveChangesAsync();
+    }
 
+    public async Task UpdateCandidateAsync(Candidate candidate)
+    {
+        _context.Candidates.Update(candidate);
         await _context.SaveChangesAsync();
     }
 }


### PR DESCRIPTION
Refactored CandidateRepository by separating responsibilities:
- Added AddCandidateAsync(), UpdateCandidateAsync(), and GetByEmailAsync()
- Removed business logic from repository to keep it focused on DB operations only, applying Single Responsibility Principle of SOLID.